### PR TITLE
Fix segfault vulnerability in C library with range checks.

### DIFF
--- a/twobit.c
+++ b/twobit.c
@@ -230,15 +230,19 @@ char byte_to_base(unsigned char byte, int offset) {
 char * twobit_sequence(TwoBit * ptr, const char * name, int start, int end) {
   struct twobit_index * seq = find_sequence(ptr->index, name);
   int size, rsize;
-  char * result;
+  char * result, * seq_dest;
   int i;
 
   if (!seq) 
     return NULL;
 
+  if (start > end)
+    return NULL;
+
   size = seq->size;
   rsize = end - start + 1;
-  result = (char*) malloc((rsize + 1) * sizeof(char));
+  seq_dest = result = (char*) malloc((rsize + 1) * sizeof(char));
+  if(result == NULL) return NULL;
   memset(result, 'N', rsize * sizeof(char)); /* initialize */
   result[rsize] = '\0';
 
@@ -246,6 +250,19 @@ char * twobit_sequence(TwoBit * ptr, const char * name, int start, int end) {
     end = size - 1;
     rsize = end - start + 1;
   }
+
+  if (start < 0)
+    {
+      rsize += start;
+      seq_dest -= start;
+      start = 0;
+    }
+  if (end < 0)
+    {
+      rsize = 0;
+      seq_dest = result;
+      end = 0;
+    };
 
   /* fill sequence */
   {
@@ -259,7 +276,7 @@ char * twobit_sequence(TwoBit * ptr, const char * name, int start, int end) {
     
     i = 0;
     while (i < rsize) {
-      result[i] = byte_to_base(*block, offset);
+      seq_dest[i] = byte_to_base(*block, offset);
 
       ++i;
       ++offset;
@@ -286,7 +303,7 @@ char * twobit_sequence(TwoBit * ptr, const char * name, int start, int end) {
       }
 
       for (j = 0, k = bstart; j < bsize && k <= end; ++j, ++k)
-	result[k - start] = 'N';
+	seq_dest[k - start] = 'N';
     }
   }
 


### PR DESCRIPTION
These range checks should prevent segfaults in clients of the C library.

Signed-off-by: Adam Wenocur <wenocur@email.chop.edu>